### PR TITLE
fix url logging

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "test": "deno test src",
+    "check": "deno fmt && deno lint && deno test",
     "example": "deno run -A example/main.ts",
     "example:web": "deno run -A example/main.ts web",
     "example:job": "deno run -A example/main.ts job",

--- a/src/controllers/log.controller.ts
+++ b/src/controllers/log.controller.ts
@@ -23,11 +23,11 @@ export class LogController<
       const { response: { status } } = ctx;
       ctx.state.context.log.info(
         "request",
-        `${status} ${method} ${url} ${ms}`,
+        `${status} ${method} ${url.pathname} ${ms}`,
         {
           status,
           method,
-          url,
+          url: `${url}`,
           ms,
           ip,
         },


### PR DESCRIPTION
The url logging is not ideal, this logs only the pathname in the message and fixes the url in the data.